### PR TITLE
Type Table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ hopefully I'll be able to port it to other platforms.
   - ~~Typecheck records~~
   - Add named types
   - Constraint solve type variables
+  - Add sum and product types
 - Lexical Analysis
   - Get closures working
 - Code gen
@@ -34,6 +35,7 @@ hopefully I'll be able to port it to other platforms.
 - Tests/Debugging
   - ~~Write some tests~~
   - ~~Add locations in errors with row/col~~
+  - Add better error messages using name and type tables
 
 ## Design
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::sync::Arc;
 
 pub type Name = usize;
+pub type TypeId = usize;
 
 // Wrapper to provide location to AST nodes
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
@@ -207,8 +208,7 @@ impl fmt::Display for Op {
     }
 }
 
-// Yeah this is hilariously basic rn.
-#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Type {
     Unit,
     Float,
@@ -217,10 +217,10 @@ pub enum Type {
     Char,
     String,
     Var(Name),
-    Array(Arc<Type>),
-    Record(Vec<(Name, Arc<Type>)>),
-    Tuple(Vec<Arc<Type>>),
-    Arrow(Arc<Type>, Arc<Type>),
+    Array(TypeId),
+    Record(Vec<(Name, TypeId)>),
+    Tuple(Vec<TypeId>),
+    Arrow(TypeId, TypeId),
 }
 
 impl fmt::Display for Type {

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -39,7 +39,7 @@ pub enum StmtT {
     Block(Vec<Loc<StmtT>>),
     Function {
         name: Name,
-        params: Vec<(Name, Arc<Type>)>,
+        params: Vec<(Name, TypeId)>,
         params_type: TypeId,
         return_type: TypeId,
         body: Box<Loc<ExprT>>,
@@ -121,7 +121,7 @@ pub enum ExprT {
     // Note: only used for anonymous functions. Functions that are
     // bound with let are TypedStmt::Function
     Function {
-        params: Vec<(Name, Arc<Type>)>,
+        params: Vec<(Name, TypeId)>,
         body: Box<Loc<ExprT>>,
         local_variables: Vec<Arc<Type>>,
         name: Name,

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -2,7 +2,6 @@ use lexer::LocationRange;
 use parser::ParseError;
 use serde::{Deserialize, Serialize};
 use std::fmt;
-use std::sync::Arc;
 
 pub type Name = usize;
 pub type TypeId = usize;
@@ -43,7 +42,7 @@ pub enum StmtT {
         params_type: TypeId,
         return_type: TypeId,
         body: Box<Loc<ExprT>>,
-        local_variables: Vec<Arc<Type>>,
+        local_variables: Vec<TypeId>,
         scope: usize,
     },
     Export(Name),
@@ -123,7 +122,7 @@ pub enum ExprT {
     Function {
         params: Vec<(Name, TypeId)>,
         body: Box<Loc<ExprT>>,
-        local_variables: Vec<Arc<Type>>,
+        local_variables: Vec<TypeId>,
         name: Name,
         scope_index: usize,
         type_: TypeId,

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -3,7 +3,8 @@ use lexer::LocationRange;
 use std::convert::TryInto;
 use std::sync::Arc;
 use symbol_table::{EntryType, SymbolTable};
-use utils::NameTable;
+use typechecker::TypeChecker;
+use utils::{NameTable, TypeTable};
 use wasm::{
     ExportEntry, ExternalKind, FunctionBody, FunctionType, ImportEntry, ImportKind, LocalEntry,
     OpCode, ProgramData, WasmType,
@@ -43,6 +44,7 @@ pub enum GenerationError {
 pub struct CodeGenerator {
     symbol_table: SymbolTable,
     name_table: NameTable,
+    type_table: TypeTable,
     // All the generated code
     program_data: ProgramData,
     return_type: Option<WasmType>,
@@ -51,11 +53,13 @@ pub struct CodeGenerator {
 type Result<T> = std::result::Result<T, GenerationError>;
 
 impl CodeGenerator {
-    pub fn new(name_table: NameTable, symbol_table: SymbolTable) -> Self {
+    pub fn new(typechecker: TypeChecker) -> Self {
+        let (symbol_table, name_table, type_table) = typechecker.get_tables();
         let func_count = symbol_table.get_function_index();
         CodeGenerator {
             symbol_table,
             name_table,
+            type_table,
             program_data: ProgramData::new(func_count),
             return_type: None,
         }

--- a/src/code_generator.rs
+++ b/src/code_generator.rs
@@ -22,8 +22,6 @@ pub enum GenerationError {
     },
     #[fail(display = "Function '{}' not defined", name)]
     FunctionNotDefined { name: String },
-    #[fail(display = "Unsupported value, probably string")]
-    UnsupportedValue,
     #[fail(display = "Cannot have () as type")]
     EmptyType,
     #[fail(display = "Code Generator: Could not infer type var {:?}", type_)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,7 @@ fn read_file(file_name: &str) -> Result<()> {
     }
     let mut typechecker = TypeChecker::new(parser.get_name_table());
     let typed_program = typechecker.check_program(program)?;
-    let (name_table, symbol_table) = typechecker.get_tables();
-    let code_generator = CodeGenerator::new(name_table, symbol_table);
+    let code_generator = CodeGenerator::new(typechecker);
     let program = code_generator.generate_program(typed_program)?;
     let out_file = File::create("build/out.wasm")?;
     let mut emitter = Emitter::new(out_file);

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,6 +1,5 @@
-use ast::{Name, Type, TypeId};
+use ast::{Name, TypeId};
 use im::hashmap::HashMap;
-use std::sync::Arc;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Scope {
@@ -61,13 +60,13 @@ impl SymbolTable {
         self.function_index
     }
 
-    pub fn reset_vars(&mut self) -> Vec<Arc<Type>> {
+    pub fn reset_vars(&mut self) -> Vec<TypeId> {
         let mut var_types = Vec::new();
         std::mem::swap(&mut var_types, &mut self.var_types);
         var_types
     }
 
-    pub fn restore_vars(&mut self, var_types: Vec<TypeId>) -> Vec<Arc<Type>> {
+    pub fn restore_vars(&mut self, var_types: Vec<TypeId>) -> Vec<TypeId> {
         let mut var_types = var_types;
         std::mem::swap(&mut self.var_types, &mut var_types);
         var_types

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -24,7 +24,7 @@ pub struct SymbolTable {
     // them into a vec, then when we finish
     // typechecking the function, we reset and spit out
     // the variable types
-    var_types: Vec<Arc<Type>>,
+    var_types: Vec<TypeId>,
     current_scope: usize,
 }
 
@@ -35,6 +35,7 @@ pub enum EntryType {
         index: usize,
         params_type: TypeId,
         return_type: TypeId,
+        type_: TypeId,
     },
     Var {
         var_type: TypeId,
@@ -66,7 +67,7 @@ impl SymbolTable {
         var_types
     }
 
-    pub fn restore_vars(&mut self, var_types: Vec<Arc<Type>>) -> Vec<Arc<Type>> {
+    pub fn restore_vars(&mut self, var_types: Vec<TypeId>) -> Vec<Arc<Type>> {
         let mut var_types = var_types;
         std::mem::swap(&mut self.var_types, &mut var_types);
         var_types
@@ -122,7 +123,7 @@ impl SymbolTable {
         None
     }
 
-    pub fn insert_var(&mut self, name: Name, var_type: Arc<Type>) {
+    pub fn insert_var(&mut self, name: Name, var_type: TypeId) {
         self.var_types.push(var_type.clone());
         self.scopes[self.current_scope].symbols.insert(
             name,
@@ -136,7 +137,13 @@ impl SymbolTable {
         );
     }
 
-    pub fn insert_function(&mut self, name: Name, params_type: TypeId, return_type: TypeId) {
+    pub fn insert_function(
+        &mut self,
+        name: Name,
+        params_type: TypeId,
+        return_type: TypeId,
+        type_: TypeId,
+    ) {
         if self.lookup_name(name).is_none() {
             self.scopes[self.current_scope].symbols.insert(
                 name,
@@ -146,6 +153,7 @@ impl SymbolTable {
                         index: self.function_index,
                         params_type,
                         return_type,
+                        type_,
                     },
                 },
             );

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -1,4 +1,4 @@
-use ast::{Name, Type};
+use ast::{Name, Type, TypeId};
 use im::hashmap::HashMap;
 use std::sync::Arc;
 
@@ -33,11 +33,11 @@ pub enum EntryType {
     Function {
         // Index into function array
         index: usize,
-        params_type: Arc<Type>,
-        return_type: Arc<Type>,
+        params_type: TypeId,
+        return_type: TypeId,
     },
     Var {
-        var_type: Arc<Type>,
+        var_type: TypeId,
         index: usize,
     },
 }
@@ -136,7 +136,7 @@ impl SymbolTable {
         );
     }
 
-    pub fn insert_function(&mut self, name: Name, params_type: Arc<Type>, return_type: Arc<Type>) {
+    pub fn insert_function(&mut self, name: Name, params_type: TypeId, return_type: TypeId) {
         if self.lookup_name(name).is_none() {
             self.scopes[self.current_scope].symbols.insert(
                 name,

--- a/src/typechecker.rs
+++ b/src/typechecker.rs
@@ -14,8 +14,6 @@ pub enum TypeError {
         location: LocationRange,
         name: String,
     },
-    #[fail(display = "{}: Typechecker - Not implemented yet", location)]
-    NotImplemented { location: LocationRange },
     #[fail(
         display = "{}: Could not find operation {} with arguments of type {} and {}",
         location, op, lhs_type, rhs_type

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ pub static UNIT_INDEX: usize = 5;
 
 impl TypeTable {
     pub fn new() -> TypeTable {
-        let mut table = TypeTable {
+        TypeTable {
             table: vec![
                 Type::Int,
                 Type::Float,
@@ -59,8 +59,7 @@ impl TypeTable {
                 Type::Bool,
                 Type::Unit,
             ],
-        };
-        table
+        }
     }
 
     pub fn insert(&mut self, type_: Type) -> TypeId {
@@ -73,7 +72,7 @@ impl TypeTable {
         self.table[id] = type_
     }
 
-    pub fn get_type(&mut self, id: TypeId) -> &Type {
+    pub fn get_type(&self, id: TypeId) -> &Type {
         &self.table[id]
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+use ast::{Type, TypeId};
 use bimap::BiMap;
 
 #[derive(Debug)]
@@ -29,5 +30,50 @@ impl NameTable {
     pub fn get_fresh_name(&mut self) -> usize {
         let ident = format!("var({})", self.1);
         self.insert(ident)
+    }
+}
+
+// "Table" is a loose term here
+pub struct TypeTable {
+    table: Vec<Type>,
+}
+
+// NOTE: This is very brittle as if
+// we change the initial vec in TypeTable
+// these constants will break
+pub static INT_INDEX: usize = 0;
+pub static FLOAT_INDEX: usize = 1;
+pub static CHAR_INDEX: usize = 2;
+pub static STR_INDEX: usize = 3;
+pub static BOOL_INDEX: usize = 4;
+pub static UNIT_INDEX: usize = 5;
+
+impl TypeTable {
+    pub fn new() -> TypeTable {
+        let mut table = TypeTable {
+            table: vec![
+                Type::Int,
+                Type::Float,
+                Type::Char,
+                Type::String,
+                Type::Bool,
+                Type::Unit,
+            ],
+        };
+        table
+    }
+
+    pub fn insert(&mut self, type_: Type) -> TypeId {
+        let index = self.table.len();
+        self.table.push(type_);
+        index
+    }
+
+    pub fn update(&mut self, id: TypeId, type_: Type) {
+        self.table[id] = type_
+    }
+
+    pub fn get_type(&mut self, id: TypeId) -> &Type {
+        &self.table[id]
     }
 }

--- a/test.sbr
+++ b/test.sbr
@@ -14,7 +14,7 @@ let foo = \() => {
     }
   };
   printString(p.name);
-  printString(p.school.name)
+  printString(p.school.name);
 }
 
 export foo;


### PR DESCRIPTION
Refactored the typechecker to use a table of types. It's similar to the name table where it associates a type to a number. That way you can mutate the type and all references will stay the same. It's basically a hack to keep the lifetimes of all the types the same while also permitting mutability.